### PR TITLE
Combined Dependabot Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <maven.clean.plugin.version>3.5.0</maven.clean.plugin.version>
     <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
     <maven.compiler.release>8</maven.compiler.release>
-    <maven.dependency.plugin.version>3.9.0</maven.dependency.plugin.version>
+    <maven.dependency.plugin.version>3.10.0</maven.dependency.plugin.version>
     <maven.install.plugin.version>3.1.4</maven.install.plugin.version>
     <maven.enforcer.plugin.version>3.6.2</maven.enforcer.plugin.version>
     <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <findsecbugs.plugin.version>1.14.0</findsecbugs.plugin.version>
     <jacoco.maven.plugin.version>0.8.14</jacoco.maven.plugin.version>
     <junit.version>4.13.2</junit.version>
-    <logback.version>1.5.27</logback.version>
+    <logback.version>1.5.32</logback.version>
     <maven.antrun.plugin.version>3.2.0</maven.antrun.plugin.version>
     <maven.assembly.plugin.version>3.8.0</maven.assembly.plugin.version>
     <maven.changelog.plugin.version>2.3</maven.changelog.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <maven.site.plugin.version>3.21.0</maven.site.plugin.version>
     <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
     <maven.surefire.plugin.version>3.5.4</maven.surefire.plugin.version>
-    <maven.surefire.report.plugin.version>3.5.4</maven.surefire.report.plugin.version>
+    <maven.surefire.report.plugin.version>3.5.5</maven.surefire.report.plugin.version>
     <maven.war.plugin.version>3.5.1</maven.war.plugin.version>
     <onejar.maven.plugin.version>1.4.4</onejar.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <maven.scm.plugin.version>2.2.1</maven.scm.plugin.version>
     <maven.site.plugin.version>3.21.0</maven.site.plugin.version>
     <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
-    <maven.surefire.plugin.version>3.5.4</maven.surefire.plugin.version>
+    <maven.surefire.plugin.version>3.5.5</maven.surefire.plugin.version>
     <maven.surefire.report.plugin.version>3.5.4</maven.surefire.report.plugin.version>
     <maven.war.plugin.version>3.5.1</maven.war.plugin.version>
     <onejar.maven.plugin.version>1.4.4</onejar.maven.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <buildnumber.maven.plugin.version>3.2.1</buildnumber.maven.plugin.version>
-    <build.helper.maven.plugin.version>3.6.0</build.helper.maven.plugin.version>
+    <build.helper.maven.plugin.version>3.6.1</build.helper.maven.plugin.version>
     <exec.maven.plugin.version>3.5.0</exec.maven.plugin.version>
     <jacoco.maven.plugin.version>0.8.12</jacoco.maven.plugin.version>
     <junit.version>4.13.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <findsecbugs.plugin.version>1.14.0</findsecbugs.plugin.version>
     <jacoco.maven.plugin.version>0.8.14</jacoco.maven.plugin.version>
     <junit.version>4.13.2</junit.version>
-    <logback.version>1.5.23</logback.version>
+    <logback.version>1.5.32</logback.version>
     <maven.antrun.plugin.version>3.2.0</maven.antrun.plugin.version>
     <maven.assembly.plugin.version>3.8.0</maven.assembly.plugin.version>
     <maven.changelog.plugin.version>2.3</maven.changelog.plugin.version>
@@ -29,7 +29,7 @@
     <maven.clean.plugin.version>3.5.0</maven.clean.plugin.version>
     <maven.compiler.plugin.version>3.14.1</maven.compiler.plugin.version>
     <maven.compiler.release>8</maven.compiler.release>
-    <maven.dependency.plugin.version>3.9.0</maven.dependency.plugin.version>
+    <maven.dependency.plugin.version>3.10.0</maven.dependency.plugin.version>
     <maven.install.plugin.version>3.1.4</maven.install.plugin.version>
     <maven.enforcer.plugin.version>3.6.2</maven.enforcer.plugin.version>
     <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
@@ -43,8 +43,8 @@
     <maven.scm.plugin.version>2.2.1</maven.scm.plugin.version>
     <maven.site.plugin.version>3.21.0</maven.site.plugin.version>
     <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
-    <maven.surefire.plugin.version>3.5.4</maven.surefire.plugin.version>
-    <maven.surefire.report.plugin.version>3.5.4</maven.surefire.report.plugin.version>
+    <maven.surefire.plugin.version>3.5.5</maven.surefire.plugin.version>
+    <maven.surefire.report.plugin.version>3.5.5</maven.surefire.report.plugin.version>
     <maven.war.plugin.version>3.5.1</maven.war.plugin.version>
     <onejar.maven.plugin.version>1.4.4</onejar.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/project-with-snapshot-dependencies/pom.xml
+++ b/project-with-snapshot-dependencies/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.6-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
This PR combines all the open Dependabot dependency updates into a single PR for easier review and merge.

Updates include:
- Logback to 1.5.32
- Maven dependency plugin to 3.10.0
- Maven surefire plugins to 3.5.5
- Maven compiler plugin to 3.15.0
- Build number plugin to 3.3.0
- Spring context to 7.0.6-SNAPSHOT
- And other minor updates